### PR TITLE
from cString to String

### DIFF
--- a/memwhisper.py
+++ b/memwhisper.py
@@ -28,7 +28,7 @@
 import itertools
 import operator
 import re
-import cStringIO
+import StringIO
 import struct
 import sys
 import time
@@ -425,10 +425,10 @@ def create(archiveList, xFilesFactor=None, aggregationMethod=None,
   aggregationMethod  specifies the function to use when propagating data (see
                      ``whisper.aggregationMethods``)
 
-  Returns in-memory file-like whisper database (cStringIO)
+  Returns in-memory file-like whisper database (StringIO)
   """
 
-  mFile = cStringIO.StringIO()
+  mFile = StringIO.StringIO()
   # Set default params
   if xFilesFactor is None:
     xFilesFactor = 0.5


### PR DESCRIPTION
**Problem**

- Either `base64` or `gzip` uses Unicode characters and unfortunately `cStringIO` doesn't support unicode. 
> Unlike the `StringIO` module, this module is not able to accept Unicode strings that cannot be encoded as plain ASCII strings. [see this](https://docs.python.org/2/library/stringio.html#module-cStringIO)

**Proposal**

- Switch to `StringIO`